### PR TITLE
Remove sass-embedded dependency

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,6 @@ exclude:
 
 sass:
   style: :compressed
-  implementation: sass-embedded
 
 theme: jekyll-theme-primer
 

--- a/jekyll-theme-primer.gemspec
+++ b/jekyll-theme-primer.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency "jekyll", ">= 4.0", "< 5.0"
   s.add_runtime_dependency "jekyll-github-metadata", "~> 2.9"
   s.add_runtime_dependency "jekyll-seo-tag", "~> 2.0"
-  s.add_runtime_dependency "sass-embedded", "~> 1.56"
+  s.add_runtime_dependency "jekyll-sass-converter", "~> 3.0"
   s.add_development_dependency "html-proofer", "~> 3.0"
   s.add_development_dependency "rubocop-github", "~> 0.16"
   s.add_development_dependency "w3c_validators", "~> 1.3"


### PR DESCRIPTION
'jekyll-sass-converter' 3.0 was released, this uses sass-embedded by default so we don't need to require it ourselves anymore. But we do need to add 'jekyll-sass-converter' with at least 3.0.

This is great timing!