### PR TITLE
Update gemspec for jekyll-v4-theme-primer

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2016-2017 GitHub, Inc.
+Copyright (c) 2022 George Waters
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/jekyll-theme-primer.gemspec
+++ b/jekyll-theme-primer.gemspec
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 Gem::Specification.new do |s|
-  s.name          = "jekyll-theme-primer"
+  s.name          = "jekyll-v4-theme-primer"
   s.version       = "0.8.0"
-  s.authors       = ["GitHub, Inc."]
-  s.email         = ["open-source@github.com"]
-  s.homepage      = "https://github.com/pages-themes/jekyll-theme-primer"
+  s.authors       = ["GitHub, Inc.", "George Waters"]
+  s.email         = ["open-source@github.com", "gwatersdev@gmail.com"]
+  s.homepage      = "https://github.com/dunkmann00/primer"
   s.summary       = "Primer is a Jekyll theme for GitHub Pages based on GitHub's Primer styles"
 
   s.files         = `git ls-files -z`.split("\x0").select do |f|


### PR DESCRIPTION
This updates the gemspec for this fork. The new name will be jekyll-v4-theme-primer. This enables putting this on rubygems, which will allow me to add it into my fork of pages-gem.