### PR TITLE
Make copy button code a template

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -24,6 +24,14 @@
       </div>
       {% endif %}
     </div>
+    <template id=clipboard_template>
+      <div>
+        <clipboard-copy aria-label="Copy" class="btn btn-invisible m-2 p-0 tooltipped-no-delay d-flex flex-justify-center flex-items-center" tabindex="0" role="button">
+          {% octicon copy height:16 %}
+          {% octicon check height:16 class:"color-fg-success d-none" %}
+        </clipboard-copy>
+      </div>
+    </template>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/4.1.0/anchor.min.js" integrity="sha256-lZaRhKri35AyJSypXXs4o6OPFTbTmUoltBbDCbdzegg=" crossorigin="anonymous"></script>
     <script>anchors.add();</script>
     <script type="module" src="{{ "/assets/js/primer-clipboard-copy.js?v=" | append: site.github.build_revision | relative_url }}"></script>

--- a/assets/js/primer-clipboard-copy.js
+++ b/assets/js/primer-clipboard-copy.js
@@ -1,52 +1,16 @@
 import './github-clipboard-copy-element.js';
-http://localhost:4000/assets/js/github_clipboard_copy_element
-String.prototype.format = function () {
-  var args = arguments;
-  return this.replace(/{([0-9]+)}/g, function (match, index) {
-    return typeof args[index] == 'undefined' ? match : args[index];
-  });
-};
-
-function fromHTML(html, trim = true) {
-  // Process the HTML string.
-  html = trim ? html.trim() : html;
-  if (!html) return null;
-
-  // Then set up a new template element.
-  const template = document.createElement('template');
-  template.innerHTML = html;
-  const result = template.content.children;
-
-  // Then return either an HTMLElement or HTMLCollection,
-  // based on whether the input HTML had one or more roots.
-  if (result.length === 1) return result[0];
-  return result;
-}
 
 function makeCopyButtons() {
-    const clipboard = `
-    <div>
-      <clipboard-copy aria-label="Copy" class="btn btn-invisible m-2 p-0 tooltipped-no-delay d-flex flex-justify-center flex-items-center" value="{0}" tabindex="0" role="button">
-        <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-copy">
-          <path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z"></path><path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"></path>
-        </svg>
-        <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-check color-fg-success d-none">
-          <path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z"></path>
-        </svg>
-      </clipboard-copy>
-    </div>
-    `
+    const clipboardTemplate = document.getElementById("clipboard_template");
 
     const blocks = document.querySelectorAll('div.highlighter-rouge>div.highlight');
     blocks.forEach((block) => {
-        // Fix quotes
-        const sanitized = block.textContent.replaceAll('"', '&quot;')
-        // Put this blocks content into the clipboard string
-        const block_clipboard = clipboard.format(sanitized);
-        // Make an html element from the block clipboard string
-        const block_clipboard_node = fromHTML(block_clipboard);
+        //Create DOM node
+        const clipboardNode = clipboardTemplate.content.cloneNode(true);
+        // Put this block's content into the clipboard-copy element's value
+        clipboardNode.querySelector("clipboard-copy").setAttribute("value", block.textContent);
         // Add it in to the end of the html code block
-        block.appendChild(block_clipboard_node);
+        block.appendChild(clipboardNode);
     });
 }
 

--- a/jekyll-v4-theme-primer.gemspec
+++ b/jekyll-v4-theme-primer.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "jekyll-github-metadata", "~> 2.16"
   s.add_runtime_dependency "jekyll-seo-tag", "~> 2.0"
   s.add_runtime_dependency "jekyll-sass-converter", "~> 3.0"
+  s.add_runtime_dependency "jekyll-octicons", "~> 19.8"
   s.add_development_dependency "html-proofer", "~> 3.0"
   s.add_development_dependency "rubocop-github", "~> 0.16"
   s.add_development_dependency "w3c_validators", "~> 1.3"


### PR DESCRIPTION
Rather than using a string in the js file, do this the "right" way and put the copy button html in the html code as a template.

This also adds the jekyll-octicons library and uses it to create the svg buttons instead of the hard coded versions originally used.